### PR TITLE
Host a race

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/bwmarrin/discordgo v0.27.1 // indirect
+	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/bwmarrin/discordgo v0.27.1 h1:ib9AIc/dom1E/fSIulrBwnez0CToJE113ZGt4Ho
 github.com/bwmarrin/discordgo v0.27.1/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=

--- a/internal/commands/host_race.go
+++ b/internal/commands/host_race.go
@@ -66,6 +66,20 @@ func (c *CommandHostRace) AppHandler(state *models.State) func(s *discordgo.Sess
 		race := state.NewRace(s, i.ChannelID, i.Member.User)
 		race.AddSnail(snail)
 
+		// Add flags to the Race
+		if len(i.ApplicationCommandData().Options) > 0 {
+			for _, opt := range i.ApplicationCommandData().Options[0].Options {
+				switch opt.Name {
+				case "no-bets":
+					race.SetNoBets()
+				case "dont-fill":
+					race.SetNoFill()
+				case "only-one":
+					race.SetOnlyOne()
+				}
+			}
+		}
+
 		// Start the race as a seperate process
 		go models.StartRace(s, race)
 

--- a/internal/commands/host_race.go
+++ b/internal/commands/host_race.go
@@ -1,0 +1,145 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/lcox74/snailrace/internal/models"
+
+	"github.com/bwmarrin/discordgo"
+	log "github.com/sirupsen/logrus"
+)
+
+type CommandHostRace struct{}
+
+func (c *CommandHostRace) Decleration() *discordgo.ApplicationCommandOption {
+	return &discordgo.ApplicationCommandOption{
+		Name:        "host",
+		Description: "Let's host a race",
+		Type:        discordgo.ApplicationCommandOptionSubCommand,
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+				Name:        "no-bets",
+				Description: "This flag skips the ability to place bets.",
+				Type:        discordgo.ApplicationCommandOptionBoolean,
+			},
+			{
+				Name:        "dont-fill",
+				Description: "If this is set, then there wont be any additional snails added if the race has less than 4 snails",
+				Type:        discordgo.ApplicationCommandOptionBoolean,
+			},
+			{
+				Name:        "only-one",
+				Description: "Continue racing until there is only one snail left. No Ties.",
+				Type:        discordgo.ApplicationCommandOptionBoolean,
+			},
+		},
+	}
+}
+
+func (c *CommandHostRace) AppHandler(state *models.State) func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	return func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+		log.Printf("[CMD] Host!\n")
+
+		// Check if the user is initialised, if the user isn't initialised then
+		// we need to tell them to initialise their account.
+		user, err := models.GetUserByDiscordID(state.DB, i.Member.User.ID)
+		if err != nil {
+			ResponseEmbedFail(s, i, true,
+				fmt.Sprintf("I'm sorry %s, but you arent initialised", i.Member.User.Username),
+				"You'll need to initialise your account with `/snailrace init` to use this command.",
+			)
+			return
+		}
+
+		// We need to get the active snail of the host to automatically add them
+		// to the race
+		snail, err := models.GetActiveSnail(state.DB, *user)
+		if err != nil {
+			ResponseEmbedFail(s, i, true,
+				fmt.Sprintf("I'm sorry %s, but we couldn't get your active snail", i.Member.User.Username),
+				"There has been an issue with the action you sent, please try again.",
+			)
+			return
+		}
+
+		// Generate the race and add the host as the first snail
+		race := state.NewRace(s, i.ChannelID, i.Member.User)
+		race.AddSnail(snail)
+
+		// Start the race as a seperate process
+		go models.StartRace(s, race)
+
+		// Respond to the interaction with a message
+		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Flags: discordgo.MessageFlagsEphemeral,
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       fmt.Sprintf("You just hosted a race %s!", i.Member.User.Username),
+						Description: "Your snail is officially waiting at the starting line for other snails to join.",
+					},
+				},
+			},
+		})
+	}
+}
+
+func (c *CommandHostRace) ActionHandler(state *models.State, options ...string) map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	return map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate){
+		models.RaceActionJoin: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			log.Printf("[CMD] Host Form Interaction!\n")
+
+			// The Join Action acts as the command /snailrace join <race_id>
+			// If the caller doesn't supply the `race_id` then we need to
+			// through and error, theoretically this should nevery error
+			if len(options) != 1 {
+				ResponseEmbedFail(s, i, true,
+					fmt.Sprintf("I'm sorry %s, but there has been an issue", i.Member.User.Username),
+					"There has been an issue with the action you sent, please try again.",
+				)
+				return
+			}
+
+			// Check if the user is initialised, if the user isn't initialised then
+			// we need to tell them to initialise their account.
+			user, err := models.GetUserByDiscordID(state.DB, i.Member.User.ID)
+			if err != nil {
+				ResponseEmbedFail(s, i, true,
+					fmt.Sprintf("I'm sorry %s, but you arent initialised", i.Member.User.Username),
+					"You'll need to initialise your account with `/snailrace init` to use this command.",
+				)
+				return
+			}
+
+			// We neet to get the user's active snail to add to the race
+			snail, err := models.GetActiveSnail(state.DB, *user)
+			if err != nil {
+				ResponseEmbedFail(s, i, true,
+					fmt.Sprintf("I'm sorry %s, but we couldn't get your active snail", i.Member.User.Username),
+					"There has been an issue with the action you sent, please try again.",
+				)
+				return
+			}
+
+			// Check if the race exists, if it doesn't then we need to tell the
+			// user
+			raceId := options[0]
+			race, ok := state.Races[raceId]
+			if !ok {
+				ResponseEmbedFail(s, i, true, fmt.Sprintf("Race %s not avaliable", raceId), "There is currently no race with the ID you supplied.")
+				return
+			}
+
+			err = race.AddSnail(snail)
+			if err != nil {
+				ResponseEmbedInfo(s, i, true, fmt.Sprintf("You're already in the race %s", i.Member.User.Username), "You can't join the race twice, good luck with the race!")
+			}
+
+			race.Render(s)
+
+			// Respond to the interaction with a message
+			ResponseEmbedSuccess(s, i, true, "Not Implemented", "This feature is not implemented yet. Sorry!")
+		},
+	}
+}

--- a/internal/commands/ping.go
+++ b/internal/commands/ping.go
@@ -13,15 +13,15 @@ import (
 // the bot it working correctly.
 type CommandPing struct{}
 
-func (c *CommandPing) Decleration() *discordgo.ApplicationCommandOption { 
+func (c *CommandPing) Decleration() *discordgo.ApplicationCommandOption {
 	return &discordgo.ApplicationCommandOption{
 		Name:        "ping",
 		Description: "Ping the bot, is it alive?",
-		Type: discordgo.ApplicationCommandOptionSubCommand,
+		Type:        discordgo.ApplicationCommandOptionSubCommand,
 	}
 }
 
-func (c *CommandPing) Handler(state *models.State) func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+func (c *CommandPing) AppHandler(state *models.State) func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	return func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		response := fmt.Sprintf("Pong <@%s>!", i.Member.User.ID)
 		log.Printf("[CMD] Ping! -> %s\n", response)
@@ -34,4 +34,8 @@ func (c *CommandPing) Handler(state *models.State) func(s *discordgo.Session, i 
 			},
 		})
 	}
+}
+
+func (c *CommandPing) ActionHandler(state *models.State, options ...string) map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	return map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate){}
 }

--- a/internal/discord.go
+++ b/internal/discord.go
@@ -11,9 +11,9 @@ import (
 )
 
 const (
-	DiscordTokenEnv   = "DISCORD_TOKEN"
-	DiscordGameStatus = "Snail Manager"
-	DiscordCmdPrefix = "snailrace"
+	DiscordTokenEnv       = "DISCORD_TOKEN"
+	DiscordGameStatus     = "Snail Manager"
+	DiscordCmdPrefix      = "snailrace"
 	DiscordCmdDescription = "Snailrace Commands"
 )
 
@@ -53,20 +53,19 @@ func SetupDiscord(state *models.State) *discordgo.Session {
 	return discord
 }
 
-
 func RegisterCommands(state *models.State, s *discordgo.Session) error {
 	// Commands to register
 	cmds := []commands.DiscordAppCommand{
 		&commands.CommandPing{},
 		&commands.CommandInitialise{},
+		&commands.CommandHostRace{},
 	}
 
 	// Create Full decleration
 	decleration := &discordgo.ApplicationCommand{
 		Name:        DiscordCmdPrefix,
 		Description: DiscordCmdDescription,
-		Options: []*discordgo.ApplicationCommandOption{
-		},
+		Options:     []*discordgo.ApplicationCommandOption{},
 	}
 
 	// Register all the commands as handlers

--- a/internal/models/race.go
+++ b/internal/models/race.go
@@ -116,5 +116,6 @@ func (r *Race) renderOpenRace(s *discordgo.Session) {
 }
 
 func StartRace(s *discordgo.Session, race *Race) {
+	log.Printf("Starting a race %+v\n", *race)
 	race.Render(s)
 }

--- a/internal/models/race.go
+++ b/internal/models/race.go
@@ -1,0 +1,120 @@
+package models
+
+import (
+	"fmt"
+
+	"github.com/bwmarrin/discordgo"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	RaceActionJoin = "host_join"
+)
+
+type Race struct {
+	Id        string
+	ChannelId string
+
+	Host    *discordgo.User
+	Message *discordgo.Message
+
+	NoBets  bool
+	NoFill  bool
+	OnlyOne bool
+
+	Snails []*Snail
+}
+
+func (r *Race) SetNoBets() {
+	r.NoBets = true
+}
+func (r *Race) SetNoFill() {
+	r.NoFill = true
+}
+func (r *Race) SetOnlyOne() {
+	r.OnlyOne = true
+}
+
+func (r *Race) AddSnail(snail *Snail) error {
+	for _, s := range r.Snails {
+		if s.ID == snail.ID {
+			return fmt.Errorf("snail already exists")
+		}
+	}
+	r.Snails = append(r.Snails, snail)
+	return nil
+}
+
+func (r *Race) Render(s *discordgo.Session) {
+	r.renderOpenRace(s)
+}
+
+func (r *Race) renderOpenRace(s *discordgo.Session) {
+	var err error
+
+	// Build the Embed Message
+	title := "Race: Open"
+	body := fmt.Sprintf(
+		"A new race has been hosted by %s\n\nRace ID: `%s`\n\nTo join via command, enter the following:\n```\n/snailrace join %s\n```\n**Entrants: (%d/12)**\n",
+		r.Host.Username,
+		r.Id,
+		r.Id,
+		len(r.Snails),
+	)
+
+	// Add the snails to the body as entrants `- <snail_name>(<@owner_id>)`
+	for _, snail := range r.Snails {
+		body += fmt.Sprintf("- %s(<@%s>)\n", snail.Name, snail.Owner.DiscordID)
+	}
+
+	// Check if this is the first message in the Race state
+	first_send := true
+	if r.Message != nil {
+		first_send = false
+	}
+
+	if first_send {
+		// Send the first message in the Race state and store the message so we
+		// can edit it later in the race state
+		r.Message, err = s.ChannelMessageSendComplex(r.ChannelId, &discordgo.MessageSend{
+			Embeds: []*discordgo.MessageEmbed{
+				{
+					Title:       title,
+					Description: body,
+					Color:       0x2ecc71,
+				},
+			},
+			Components: []discordgo.MessageComponent{
+				discordgo.ActionsRow{
+					Components: []discordgo.MessageComponent{
+						discordgo.Button{
+							Label:    "Join",
+							Style:    discordgo.SuccessButton,
+							CustomID: fmt.Sprintf("%s:%s", RaceActionJoin, r.Id),
+						},
+					},
+				},
+			},
+		})
+
+		if err != nil {
+			log.Println(err)
+		}
+
+	} else {
+		// Edit the message to reflect the current state of the race, in this
+		// sense it will mainly update the entrants
+		edit := discordgo.NewMessageEdit(r.ChannelId, r.Message.ID)
+		edit.Embeds = []*discordgo.MessageEmbed{
+			{
+				Title:       title,
+				Description: body,
+			},
+		}
+		s.ChannelMessageEditComplex(edit)
+	}
+}
+
+func StartRace(s *discordgo.Session, race *Race) {
+	race.Render(s)
+}

--- a/internal/models/snail.go
+++ b/internal/models/snail.go
@@ -22,10 +22,10 @@ const (
 type Snail struct {
 	gorm.Model
 
-	Name  string `json:"name"`
-	OwnerID string  `json:"-"`
-	Owner User   `json:"owner"  gorm:"references:DiscordID"` 
-	Active bool   `json:"active" gorm:"default:false"`
+	Name    string `json:"name"`
+	OwnerID string `json:"-"`
+	Owner   User   `json:"owner"  gorm:"references:DiscordID"`
+	Active  bool   `json:"active" gorm:"default:false"`
 
 	Level uint64 `json:"level" gorm:"default:1"`
 	Exp   uint64 `json:"exp" gorm:"default:0"`
@@ -81,13 +81,13 @@ func CreateSnail(db *gorm.DB, owner User, levelType SnailStatLevel) (*Snail, err
 
 func GetAllSnails(db *gorm.DB, owner User) ([]Snail, error) {
 	snails := []Snail{}
-	result := db.Where("owner_id = ?", owner.DiscordID).Find(&snails)
+	result := db.Where("owner_id = ?", owner.DiscordID).Preload("Owner").Find(&snails)
 	return snails, result.Error
 }
 
 func GetActiveSnail(db *gorm.DB, owner User) (*Snail, error) {
 	snail := &Snail{}
-	result := db.Where("owner_id = ? AND active = ?", owner.DiscordID, true).First(snail)
+	result := db.Where("owner_id = ? AND active = ?", owner.DiscordID, true).Preload("Owner").First(snail)
 	return snail, result.Error
 }
 

--- a/internal/models/state.go
+++ b/internal/models/state.go
@@ -1,11 +1,39 @@
 package models
 
-import "gorm.io/gorm"
+import (
+	"github.com/bwmarrin/discordgo"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
 
 type State struct {
-	DB *gorm.DB
+	DB    *gorm.DB
+	Races map[string]*Race
 }
 
 func NewState(db *gorm.DB) *State {
-	return &State{DB: db}
+	return &State{
+		DB:    db,
+		Races: make(map[string]*Race, 0),
+	}
+}
+
+func (s *State) NewRace(session *discordgo.Session, channelId string, host *discordgo.User) *Race {
+	// Generate Unique ID
+	id := uuid.New().String()[24:]
+	_, ok := s.Races[id]
+	for ok {
+		id = uuid.New().String()[24:]
+		_, ok = s.Races[id]
+	}
+
+	// Create New Race
+	race := &Race{
+		Id:        id,
+		ChannelId: channelId,
+		Host:      host,
+	}
+	s.Races[id] = race
+
+	return race
 }


### PR DESCRIPTION
This closes #1 

Features applied:
- Host a race (doesn't start)
- Enable and save (`dont-fill`, `only-one`, `no-bets`) flags into the race state
- Notify the user that they have hosted using ephemeral
- Create a Race state which renders and re-renders (edits) an single message 
- Join the race via Discord Button UI (not cmd yet) this will update the race message with the extra entrant
- Log errors, and notify to the user ephemerally that there was an issue
- Notify the user if they are already in the race