### PR TITLE
display wallet amounts with commas

### DIFF
--- a/internal/commands/wallet.go
+++ b/internal/commands/wallet.go
@@ -3,6 +3,9 @@ package commands
 import (
 	"fmt"
 
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
+
 	"github.com/bwmarrin/discordgo"
 	"github.com/lcox74/snailrace/internal/models"
 	log "github.com/sirupsen/logrus"
@@ -34,7 +37,8 @@ func (c *WalletCommand) AppHandler(state *models.State) func(s *discordgo.Sessio
 		}
 
 		// Display the users wallet
-		ResponseEmbedSuccess(s, i, true, "Wallet", fmt.Sprintf("💰 %dg", user.Money))
+		p := message.NewPrinter(language.English)
+		ResponseEmbedSuccess(s, i, true, "Wallet", p.Sprintf("💰 %dg", user.Money))
 
 	}
 }


### PR DESCRIPTION
As some users have amassed truly staggering amounts of money, we should display wallets with thousands separators. This will enable both wallet-owners and bystanders to more easily grasp the true grandeur and heights of wealth achievable by gambling on snailraces.